### PR TITLE
課題3実装

### DIFF
--- a/src/components/PostDetail.js
+++ b/src/components/PostDetail.js
@@ -1,11 +1,11 @@
-export default function PostDetail({ posts, id }) {
+export default function PostDetail({ post }) {
   const formatDate = (date) => {
     // 日時をyyyy/MM/DD形式にフォーマット
     const yeardate = new Date(date.createdAt).toLocaleString().split(" ", 1);
     return yeardate;
   };
 
-  const post = posts.find((item) => item.id === Number(id));
+  // const post = posts.find((item) => item.id === Number(id));
 
   if (!post) return <p className="text-left">投稿が見つかりませんでした</p>;
 
@@ -18,7 +18,7 @@ export default function PostDetail({ posts, id }) {
         <div className="flex justify-between mx-auto m-3 ">
           <p className="m-2 text-gray-400">{formatDate(post)}</p>
           <div className="flex space-x-2 ">
-            {post.categories.map((category, index) => (
+            {post.categories?.map((category, index) => (
               <p
                 key={index}
                 className="p-1 text-blue-500 border border-blue-300 rounded-md "

--- a/src/components/PostDetailPage.js
+++ b/src/components/PostDetailPage.js
@@ -1,15 +1,31 @@
-import { useLocation, useParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import PostDetail from "./PostDetail";
+import { useEffect, useState } from "react";
 
 export default function PostDetailPage() {
   // ルートパラメータを取得
   const { id } = useParams();
-  const { state: posts } = useLocation();
-  // console.log(posts);
+  const [post, setPost] = useState([]);
+  // const { state: posts } = useLocation();
+
+  // APIでpostを取得する処理をuseEffectで実行
+  useEffect(() => {
+    const fetcher = async () => {
+      const res = await fetch(
+        `https://1hmfpsvto6.execute-api.ap-northeast-1.amazonaws.com/dev/posts/${id}`
+      );
+      const data = await res.json();
+
+      setPost(data.post);
+    };
+
+    fetcher();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div>
-      <PostDetail posts={posts} id={id} />
+      <PostDetail post={post} />
     </div>
   );
 }

--- a/src/components/PostDetailPage.js
+++ b/src/components/PostDetailPage.js
@@ -1,10 +1,12 @@
-import { useParams } from "react-router-dom";
-import { posts } from "../data/posts";
+import { useLocation, useParams } from "react-router-dom";
 import PostDetail from "./PostDetail";
 
 export default function PostDetailPage() {
   // ルートパラメータを取得
   const { id } = useParams();
+  const { state: posts } = useLocation();
+  // console.log(posts);
+
   return (
     <div>
       <PostDetail posts={posts} id={id} />

--- a/src/components/PostDetailPage.js
+++ b/src/components/PostDetailPage.js
@@ -6,6 +6,7 @@ export default function PostDetailPage() {
   // ルートパラメータを取得
   const { id } = useParams();
   const [post, setPost] = useState([]);
+  const [isLoading, setLoading] = useState(true);
   // const { state: posts } = useLocation();
 
   // APIでpostを取得する処理をuseEffectで実行
@@ -17,11 +18,14 @@ export default function PostDetailPage() {
       const data = await res.json();
 
       setPost(data.post);
+      setLoading(false);
     };
 
     fetcher();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  if (isLoading) return <p className="text-left">読み込み中...</p>;
 
   return (
     <div>

--- a/src/components/PostList.js
+++ b/src/components/PostList.js
@@ -11,7 +11,7 @@ export default function PostList({ posts }) {
     <ul className="max-w-4xl grid grid-cols-1 gap-2 mx-auto mt-6 ">
       {posts.map((post) => (
         <li key={post.id} className="h-auto m-5 p-3 border border-slate-400 ">
-          <Link to={`/posts/${post.id}`} state={posts}>
+          <Link to={`/posts/${post.id}`}>
             <div className="flex justify-between mx-auto  ">
               <p className="text-gray-400 m-2">{formatDate(post)}</p>
               <div className="flex space-x-2 ">

--- a/src/components/PostList.js
+++ b/src/components/PostList.js
@@ -11,7 +11,7 @@ export default function PostList({ posts }) {
     <ul className="max-w-4xl grid grid-cols-1 gap-2 mx-auto mt-6 ">
       {posts.map((post) => (
         <li key={post.id} className="h-auto m-5 p-3 border border-slate-400 ">
-          <Link to={`/posts/${post.id}`}>
+          <Link to={`/posts/${post.id}`} state={posts}>
             <div className="flex justify-between mx-auto  ">
               <p className="text-gray-400 m-2">{formatDate(post)}</p>
               <div className="flex space-x-2 ">

--- a/src/components/TopPage.js
+++ b/src/components/TopPage.js
@@ -3,6 +3,7 @@ import PostList from "./PostList";
 
 export default function TopPage() {
   const [posts, setPosts] = useState([]);
+  const [isLoading, setLoading] = useState(true);
 
   // APIでpostsを取得する処理をuseEffectで実行します。
   useEffect(() => {
@@ -12,10 +13,13 @@ export default function TopPage() {
       );
       const data = await res.json();
       setPosts(data.posts);
+      setLoading(false);
     };
 
     fetcher();
   }, []);
+
+  if (isLoading) return <p className="text-left">読み込み中...</p>;
 
   return (
     <>

--- a/src/components/TopPage.js
+++ b/src/components/TopPage.js
@@ -1,7 +1,22 @@
-import { posts } from "../data/posts";
+import { useEffect, useState } from "react";
 import PostList from "./PostList";
 
 export default function TopPage() {
+  const [posts, setPosts] = useState([]);
+
+  // APIでpostsを取得する処理をuseEffectで実行します。
+  useEffect(() => {
+    const fetcher = async () => {
+      const res = await fetch(
+        "https://1hmfpsvto6.execute-api.ap-northeast-1.amazonaws.com/dev/posts"
+      );
+      const data = await res.json();
+      setPosts(data.posts);
+    };
+
+    fetcher();
+  }, []);
+
   return (
     <>
       <div>


### PR DESCRIPTION
・APIを使ったデータ取得
・useEffectを用いたページ読込時のAPI呼び出し
・記事一覧ページと記事詳細ページそれぞれでAPIを呼び出すと冗長に
思われたので、ページ遷移(PostList→PsotDetailPage)に伴い、postsの値を
渡すように修正しました。